### PR TITLE
DES-192: Changes `order_by_option_values` to return all variants ordered.

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,14 +1,15 @@
 Spree::Variant.class_eval do
   # Sorts by option value position and other criteria after variant position.
   scope :order_by_option_value, ->{
-    joins(:option_values).unscope(:order).order(
+    left_outer_joins(:option_values)
+    .unscope(:order).order(
       position: :asc
     ).order(
       'spree_option_values.position ASC'
     ).order(
       is_master: :desc,
       id: :asc
-    ).distinct
+    )
   }
 
   # Returns this variant's option value for its product's first option type.

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -11,13 +11,13 @@ describe Spree::ProductsController, type: :controller do
   end
 
   describe '#show' do
-    it 'returns only variants with option values' do
+    it 'returns all variants even if they dont have option values' do
       product = create(:product_with_option_types)
       create(:base_variant, product: product) # this has option values
       create(:base_variant, product: product, option_values: [])
 
       get :show, params: { id: product.to_param }
-      expect(assigns['variants'].count).to eq(1)
+      expect(assigns['variants'].count).to eq(3)
     end
   end
 end


### PR DESCRIPTION
We were seeing certain products that would display no variants to be
sold which means they couldn't add that product to their cart because
it was using a inner join which meant to be a variant to be sold it
would have to have an option_value. Changing that to a left_outer join
means it shows all variants reguardless if they have an option_value.